### PR TITLE
fix: ensure dark theme and simplify header links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,11 @@ const shipporiMincho = Shippori_Mincho({
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang='ja' className={shipporiMincho.className} suppressHydrationWarning>
+    <html
+      lang='ja'
+      className={`dark ${shipporiMincho.className}`}
+      suppressHydrationWarning
+    >
       <body className='bg-[#282828] flex min-h-dvh flex-col'>
         {process.env.NODE_ENV === 'production' && (
           <>

--- a/src/components/BuyMeACoffee.tsx
+++ b/src/components/BuyMeACoffee.tsx
@@ -1,9 +1,8 @@
 import Image from 'next/image';
-import Link from 'next/link';
 
 export const BuyMeACoffee = () => {
   return (
-    <Link
+    <a
       href='https://www.buymeacoffee.com/buntin'
       target='_blank'
       rel='noopener noreferrer'
@@ -15,6 +14,6 @@ export const BuyMeACoffee = () => {
         width={30}
         height={30}
       />
-    </Link>
+    </a>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,12 @@ import { usePathname } from 'next/navigation';
 export const Header = () => {
   const pathname = usePathname();
 
+  const navItems = [
+    { href: '/posts', label: 'Blog', Icon: Newspaper },
+    { href: '/categories', label: 'Categories', Icon: Folders },
+    { href: '/tags', label: 'Tags', Icon: Tags },
+  ];
+
   return (
     <div className='mb-4 text-center'>
       <div className='my-4'>
@@ -15,30 +21,16 @@ export const Header = () => {
         </Link>
       </div>
       <div className='flex justify-between w-4/5 sm:w-1/2 xl:w-1/3 mx-auto text-xl'>
-        <Link href='/posts' className='flex'>
-          <Newspaper className='my-auto mr-1' />
-          {pathname === '/posts' ? (
-            <span className='underline'>Blog</span>
-          ) : (
-            <span className='hover:underline'>Blog</span>
-          )}
-        </Link>
-        <Link href='/categories' className='flex'>
-          <Folders className='my-auto mr-1' />
-          {pathname === '/categories' ? (
-            <span className='underline'>Categories</span>
-          ) : (
-            <span className='hover:underline'>Categories</span>
-          )}
-        </Link>
-        <Link href='/tags' className='flex'>
-          <Tags className='my-auto mr-1' />
-          {pathname === '/tags' ? (
-            <span className='underline'>Tags</span>
-          ) : (
-            <span className='hover:underline'>Tags</span>
-          )}
-        </Link>
+        {navItems.map(({ href, label, Icon }) => (
+          <Link key={href} href={href} className='flex'>
+            <Icon className='my-auto mr-1' />
+            {pathname === href ? (
+              <span className='underline'>{label}</span>
+            ) : (
+              <span className='hover:underline'>{label}</span>
+            )}
+          </Link>
+        ))}
       </div>
       <div className='border border-[#a89984] mt-4 mb-2 mx-3' />
     </div>


### PR DESCRIPTION
## Summary
- avoid flash of light theme by setting `dark` class on the initial HTML element
- replace `next/link` with an anchor for external Buy Me A Coffee link
- reduce repetition in header navigation by mapping over a link list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2e04ede288323970c95617a49b7e2