### PR TITLE
Fumadocsコンポーネントの配色を既存デザインに統一

### DIFF
--- a/src/app/(home)/posts/[slug]/page.tsx
+++ b/src/app/(home)/posts/[slug]/page.tsx
@@ -49,7 +49,7 @@ const PostPage = async ({ params }: PageProps<'/posts/[slug]'>) => {
         <p className="my-4 text-center">{post.data.description}</p>
         <InlineTOC
           items={post.data.toc}
-          className="blog-inline-toc mb-10 bg-[#242424] text-[#fbf1c7] [&_a]:border-s-0"
+          className="blog-inline-toc mb-10 bg-fd-muted text-[#fbf1c7] [&_a]:border-s-0"
         >
           目次
         </InlineTOC>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -16,6 +16,12 @@ body {
 }
 
 .blog-shell {
+  --color-fd-foreground: #fbf1c7;
+  --color-fd-card-foreground: #fbf1c7;
+  --color-fd-popover-foreground: #fbf1c7;
+  --color-fd-primary: #fbf1c7;
+  --color-fd-secondary-foreground: #fbf1c7;
+  --color-fd-accent-foreground: #d5c4a1;
   color: #fbf1c7;
 }
 


### PR DESCRIPTION
## 概要

- ブログ領域内でFumadocsが使用する主要な前景色トークンを、既存デザインの黄系配色へ統一しました。
- インライン目次の背景を、Markdownテーブルのヘッダーと同じ `fd-muted` トークンへ変更しました。

## 背景と原因

Fumadocs更新後のTypographyおよびUIコンポーネントは、継承された本文色ではなく `fd-foreground` や `fd-card-foreground` などの専用トークンを使用します。そのため、ブログ全体で黄系の文字色を指定していても、テーブルヘッダーなど一部の新しいコンポーネントだけNeutralテーマ既定の白色で表示されていました。

個々の要素へ場当たり的な色指定を追加するのではなく、ブログ領域内だけFumadocsの前景色トークンを既存配色へ対応付けています。構文ハイライトと補助的なグレーは意図的な配色として維持しています。

## 影響

- テーブルヘッダーの文字が本文と同じ黄系になります。
- 目次背景とテーブルヘッダー背景が同じ色になります。
- Card、Callout、Popover、Secondary、Accentなど、同じFumadocsトークンを使う部品でも白色が混入しにくくなります。
- Categoriesなど従来から黄色で表示しているリンク、および記事内の青い通常リンクは変更しません。
- コンテンツ、フロントマター、SEO、URL、生成画像への変更はありません。

## 検証

- `bun run ci`
  - frozen lockfile install
  - OxLint（警告をエラー扱い）
  - TypeScript 7型検査
  - TypeScript 6互換型検査
  - Next.js本番ビルド
  - 静的ページ生成 72/72
- `bun run start` による `localhost:3000` の本番ビルド確認
- デスクトップ幅および狭幅での目視確認
- 計算後スタイルの確認
  - テーブルヘッダー背景: `rgb(33, 33, 33)`
  - 目次背景: `rgb(33, 33, 33)`
  - テーブルヘッダー文字: `rgb(251, 241, 199)`
  - 意図しない白色テキスト: 0件
